### PR TITLE
Revert "Use task cwd option instead of cd"

### DIFF
--- a/tasks.json
+++ b/tasks.json
@@ -37,10 +37,10 @@
         {
             "label": "prosv5 Build",
             "type": "shell",
-            "windows": { "command": "./.vscode/run_docker.ps1 'prosv5 build'" },
-            "linux": { "command": "pwsh ./.vscode/run_docker.ps1 'prosv5 build'" },
+            "windows": { "command": "./.vscode/run_docker.ps1 'cd src/v5_hal/firmware && prosv5 build'" },
+            "linux": { "command": "pwsh ./.vscode/run_docker.ps1 'cd src/v5_hal/firmware && prosv5 build'" },
             "options": {
-                "cwd": "${workspaceFolder}/src/v5_hal/firmware"
+                "cwd": "${workspaceFolder}"
             },
             "problemMatcher": {
                 "owner": "prosv5",


### PR DESCRIPTION
This reverts the pros build task to using a cd command instead of the cwd task option because it needs to change the directory inside the Docker container.